### PR TITLE
Add option to name a webhook

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,7 +75,7 @@ def delete_route_json(route_path):
     })
 
 
-@app.route('/inspect/<string:route_path>', methods=['GET'])
+@app.route('/inspect/<string:route_path>', methods=['GET', 'POST'])
 def inspect(route_path):
     # Lookup route
     route = RouteModel.query.filter_by(path=route_path).first()
@@ -83,6 +83,10 @@ def inspect(route_path):
     # Return 404 if unknown route
     if not route:
         return redirect(url_for('abort_404')), 307
+
+    # Rename route
+    if request.method == 'POST' and request.form.get('set_name'):
+        routes_handler.rename(route, request.form['set_name'])
 
     # Get callbacks
     callbacks = callback_handler.get_callbacks(
@@ -93,7 +97,10 @@ def inspect(route_path):
         route_path=route_path,
         callbacks=callbacks,
         cursor=callback_handler.get_cursor(callbacks),
-        host_url=request.host_url
+        host_url=request.host_url,
+        name=route.name or '',
+        name_default='Route created on %s' % (
+            (route.creation_date).strftime("%A %B %d, %Y at %H:%M:%S")),
     )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -140,6 +140,7 @@ def inspect_json(route_path):
         'callbacks': callbacks,
         'creation_date': route.creation_date,
         'expiration_date': route.expiration_date,
+        'name': route.name,
         'next': request.host_url + 'api/inspect/' + route_path + '?cursor=' + str(cursor) if cursor else None
     })
 

--- a/src/models.py
+++ b/src/models.py
@@ -35,6 +35,7 @@ class RouteModel(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     path = db.Column(db.String(80), unique=True, nullable=False, index=True)
+    name = db.Column(db.String(255))
     creation_date = db.Column(
         db.DateTime, nullable=False, default=datetime.now, index=True)
     expiration_date = db.Column(

--- a/src/routes_handler.py
+++ b/src/routes_handler.py
@@ -21,7 +21,7 @@ def rename(route, name):
     if not name:
         return None
 
-    # Delete callbacks
+    # Rename the route
     route.name = name
 
     # Commit

--- a/src/routes_handler.py
+++ b/src/routes_handler.py
@@ -15,6 +15,19 @@ def new():
     return route
 
 
+def rename(route, name):
+    """ Rename a route """
+
+    if not name:
+        return None
+
+    # Delete callbacks
+    route.name = name
+
+    # Commit
+    db.session.commit()
+
+
 def cleanup_old_routes():
     """ Delete expired routes """
 

--- a/src/templates/inspect.html
+++ b/src/templates/inspect.html
@@ -7,6 +7,15 @@
     <input type="text" class="form-control" aria-label="Sizing example input" aria-describedby="inputGroup-sizing-default" value="{{ host_url }}{{ route_path }}">
 </div>
 
+<form method="POST" action="/inspect/{{ route_path }}">
+    <div class="input-group mb-3">
+        <input type="text" name="set_name" class="form-control" placeholder="{{ name_default }}" value="{{ name }}" aria-label="Webhook name" aria-describedby="button-addon2">
+        <div class="input-group-append">
+        <button class="btn btn-outline-secondary" type="submit" id="button-addon2">Rename</button>
+        </div>
+    </div>
+</form>
+
 {% if callbacks %}
     <div class="alert alert-primary" role="alert">
             Webhook example:

--- a/src/templates/inspect.html
+++ b/src/templates/inspect.html
@@ -9,7 +9,7 @@
 
 <form method="POST" action="/inspect/{{ route_path }}">
     <div class="input-group mb-3">
-        <input type="text" name="set_name" class="form-control" placeholder="{{ name_default }}" value="{{ name }}" aria-label="Webhook name" aria-describedby="button-addon2">
+        <input type="text" name="set_name" class="form-control" placeholder="{{ name_default }}" value="{{ name }}" aria-label="Webhook name" aria-describedby="button-addon2" maxlength="255">
         <div class="input-group-append">
         <button class="btn btn-outline-secondary" type="submit" id="button-addon2">Rename</button>
         </div>

--- a/src/unittest/test_app.py
+++ b/src/unittest/test_app.py
@@ -127,6 +127,19 @@ class Test(BaseTest):
         assert b'Current route' in rv.data
         assert b'looking+for+this+string' in rv.data
 
+    def test_inspect_rename(self):
+        # Generate a new path
+        route = routes_handler.new()
+        path = route.path
+
+        # Try sending some data to the webhook URL
+        rv = self.client.post('/inspect/' + path, data=dict(
+            set_name='New route name'
+        ))
+
+        assert rv.status_code == 200
+        assert b'New route name' in rv.data
+
     def test_inspect_invalid(self):
         rv = self.client.get('/inspect/some_bad_route')
         # Should be a 307 to redirect to 404

--- a/src/unittest/test_app.py
+++ b/src/unittest/test_app.py
@@ -155,6 +155,7 @@ class Test(BaseTest):
         self.assertIsInstance(rv.json['routes']['webhook'], str)
         self.assertIsInstance(rv.json['creation_date'], str)
         self.assertIsInstance(rv.json['expiration_date'], str)
+        self.assertIsNone(rv.json['name'], None)
         self.assertIsNone(rv.json['next'])
 
     def test_api_inspect_cursor(self):

--- a/src/unittest/test_app.py
+++ b/src/unittest/test_app.py
@@ -155,7 +155,7 @@ class Test(BaseTest):
         self.assertIsInstance(rv.json['routes']['webhook'], str)
         self.assertIsInstance(rv.json['creation_date'], str)
         self.assertIsInstance(rv.json['expiration_date'], str)
-        self.assertIsNone(rv.json['name'], None)
+        self.assertIsNone(rv.json['name'])
         self.assertIsNone(rv.json['next'])
 
     def test_api_inspect_cursor(self):

--- a/src/unittest/test_app.py
+++ b/src/unittest/test_app.py
@@ -132,7 +132,7 @@ class Test(BaseTest):
         route = routes_handler.new()
         path = route.path
 
-        # Try sending some data to the webhook URL
+        # Sending a POST with a new webhook name
         rv = self.client.post('/inspect/' + path, data=dict(
             set_name='New route name'
         ))

--- a/src/unittest/test_models.py
+++ b/src/unittest/test_models.py
@@ -44,6 +44,7 @@ class Test(BaseTest):
         self.assertIsInstance(self.route.path, str)
         self.assertIsInstance(self.route.creation_date, datetime)
         self.assertIsInstance(self.route.expiration_date, datetime)
+        self.assertIsNone(self.route.name)
 
     def test_RouteModel_repr(self):
         self.route = models.RouteModel(path=str(uuid.uuid4()))

--- a/src/unittest/test_routes_handler.py
+++ b/src/unittest/test_routes_handler.py
@@ -38,6 +38,20 @@ class Test(BaseTest):
         self.assertIsInstance(route.path, str)
         assert len(route.path) == 36
 
+    def test_rename(self):
+        route = routes_handler.new()
+
+        # Default name should be None
+        assert route.name is None
+
+        # Rename route with empty name
+        routes_handler.rename(route, '')
+        assert route.name is None
+
+        # Rename route with a valid name
+        routes_handler.rename(route, 'New route name')
+        assert route.name == 'New route name'
+
     def test_cleanup_old_routes(self):
         # Create 2 routes, one expired
         self.route_1 = RouteModel(path=str(uuid.uuid4()), )


### PR DESCRIPTION
Routes will have a default name:

<img width="725" alt="Screenshot 2019-12-26 13 50 23" src="https://user-images.githubusercontent.com/8358050/71486974-d05df000-27e6-11ea-9322-859bfa0b2c80.png">

And users will be able to set a custom name:

<img width="730" alt="Screenshot 2019-12-26 13 51 07" src="https://user-images.githubusercontent.com/8358050/71486981-d81d9480-27e6-11ea-85bb-0e3db35251f0.png">

Required migration:

```sql
ALTER TABLE routes ADD COLUMN name VARCHAR(255);
```