### PR TITLE
Correctly report UTC TZ in API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.6"
 before_install:
+  - export TZ=EST
   - sudo apt-get update
   - pip install pycodestyle codecov
   - pip install -r requirements.txt

--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import timezone
 
 from flask import Flask, render_template, request, redirect, url_for, send_from_directory, jsonify
 
@@ -10,6 +11,19 @@ from .models import db, RouteModel, CallbackModel
 
 
 app = get_or_create_app()
+
+
+@app.template_filter('strftime')
+def _jinja2_filter_datetime(date, fmt=None):
+    """
+        Custom Jinja filter to convert UTC date to local TZ
+        and return it formatted
+    """
+
+    # Convert UTC to local TZ
+    date = date.replace(tzinfo=timezone.utc).astimezone(tz=None)
+
+    return date.strftime(fmt) if fmt else date.strftime('%B %d, %Y %I:%M:%S %p')
 
 
 @app.route("/")
@@ -100,7 +114,7 @@ def inspect(route_path):
         host_url=request.host_url,
         name=route.name or '',
         name_default='Route created on %s' % (
-            (route.creation_date).strftime("%A %B %d, %Y at %H:%M:%S")),
+            (route.creation_date.replace(tzinfo=timezone.utc).astimezone(tz=None)).strftime("%A %B %d, %Y at %I:%M:%S %p")),
     )
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -37,9 +37,9 @@ class RouteModel(db.Model):
     path = db.Column(db.String(80), unique=True, nullable=False, index=True)
     name = db.Column(db.String(255))
     creation_date = db.Column(
-        db.DateTime, nullable=False, default=datetime.now, index=True)
+        db.DateTime, nullable=False, default=datetime.utcnow, index=True)
     expiration_date = db.Column(
-        db.DateTime, default=lambda: parse(Config().webhook_expire) if Config().webhook_expire else None, index=True)
+        db.DateTime, default=lambda: parse(Config().webhook_expire, settings={'TIMEZONE': 'UTC'}) if Config().webhook_expire else None, index=True)
 
     def __repr__(self):
         return '<Route %r>' % self.path
@@ -55,7 +55,7 @@ class CallbackModel(db.Model):
     args = db.Column(db.Text())
     body = db.Column(db.Text())
     date = db.Column(
-        db.DateTime, nullable=False, default=datetime.now)
+        db.DateTime, nullable=False, default=datetime.utcnow)
     referrer = db.Column(db.Text())
     remote_addr = db.Column(db.String(256))
 

--- a/src/routes_handler.py
+++ b/src/routes_handler.py
@@ -33,7 +33,7 @@ def cleanup_old_routes():
 
     # Load routes
     routes = RouteModel.query.filter(
-        RouteModel.expiration_date < datetime.now(), RouteModel.expiration_date.isnot(None)).all()
+        RouteModel.expiration_date < datetime.utcnow(), RouteModel.expiration_date.isnot(None)).all()
 
     for route in routes:
         delete(route)

--- a/src/templates/inspect.html
+++ b/src/templates/inspect.html
@@ -32,7 +32,7 @@ curl -X POST {{ host_url }}{{ route_path }} \
         {% set rowloop = loop %}
 
         <div class="border border table-responsive" style="padding: 6px; margin-bottom: 4px;">
-            <h5>{{ callback.date.strftime('%B %d, %Y %I:%M:%S %p') }}</h5>
+            <h5>{{ callback.date | strftime }}</h5>
 
             <div style="text-align: right;">
                 <a href="/api/delete/{{ route_path }}/{{ callback.id }}" target="_blank" onclick="return confirm('Confirm callback deletion?');"><button type="button" class="btn btn-danger btn-secondary btn-sm">Delete (Json)</button></a>
@@ -46,7 +46,7 @@ curl -X POST {{ host_url }}{{ route_path }} \
                         </tr>
                         <tr>
                             <td>Date</td>
-                            <td>{{ callback.date.strftime('%B %d, %Y %I:%M:%S %p') }}</td>
+                            <td>{{ callback.date | strftime }}</td>
                         </tr>
                         {% if callback.referrer %}
                             <tr>

--- a/src/unittest/test_app.py
+++ b/src/unittest/test_app.py
@@ -1,9 +1,32 @@
 
+from datetime import datetime
+
 from .base import BaseTest
 from .. import app, bootstrap, routes_handler
 
 
 class Test(BaseTest):
+
+    def test__jinja2_filter_datetime(self):
+        """
+            Test Jinja custom filter that converts a date
+            from UTC to local TZ and returns output as a str
+        """
+
+        dt = datetime(2020, 2, 26, 19, 42, 23, 824725)
+        assert app._jinja2_filter_datetime(
+            dt) == 'February 26, 2020 02:42:23 PM'
+
+    def test__jinja2_filter_datetime_2(self):
+        """
+            Test Jinja custom filter that converts a date
+            from UTC to local TZ and returns output as a str
+            with a custom formt
+        """
+
+        dt = datetime(2020, 2, 26, 19, 42, 23, 824725)
+        assert app._jinja2_filter_datetime(
+            dt, fmt='%B %d, %Y') == 'February 26, 2020'
 
     def test_hp(self):
         rv = self.client.get('/')

--- a/src/unittest/test_app.py
+++ b/src/unittest/test_app.py
@@ -21,7 +21,7 @@ class Test(BaseTest):
         """
             Test Jinja custom filter that converts a date
             from UTC to local TZ and returns output as a str
-            with a custom formt
+            with a custom format
         """
 
         dt = datetime(2020, 2, 26, 19, 42, 23, 824725)


### PR DESCRIPTION
 - Store dates as UTC in the db instead of the local TZ
 - Correctly report UTC TZ in API (instead of falsely reporting the local TZ as UTC)
 - Implement logic to convert UTC dates to the local TZ in the UI